### PR TITLE
Hid status field

### DIFF
--- a/src/templates/AddItemPage.html
+++ b/src/templates/AddItemPage.html
@@ -87,12 +87,16 @@
   
     <label for="price">Price per Item</label>
     <input name="price" type="number" step="0.01" min="0" placeholder="Price per item" required>
-
+    
+<!-- Hid this input to not show this field when adding an item and always be set to "active" -->
+    <input type="hidden" name="status" value="active">
+<!--
     <label for="status">Status</label>
     <select name="status">
         <option value="active" selected>Active</option>
         <option value="inactive">Inactive</option>
     </select>
+-->
 
 
     <button type="submit" class="text">Add</button>
@@ -112,4 +116,5 @@
 
 
 {% endblock %}
+
 


### PR DESCRIPTION
All the code is still there, but proposed a change to one field on the form.  Instead of having the user select active or inactive to an item being added to the db, the item will always be added as active and the option will not be displayed to user.  Did not commit directly to talk to you first.
<img width="218" height="254" alt="image" src="https://github.com/user-attachments/assets/e44aa4cf-e61f-4d30-acea-e9babec3270d" />
